### PR TITLE
chore(graphql-codegen): prevent input object type and enum generating

### DIFF
--- a/graphql-codegen.ts
+++ b/graphql-codegen.ts
@@ -26,9 +26,8 @@ export default {
         useTypeImports: true,
         declarationKind: 'interface',
         strictScalars: true,
-        // Because no DocumentMode exported from library, generate
-        // "gql`...` as unknown as DocumentNode<query, variables>" to prevent manual addition
-        // of generics useGqlQuery / useGqlMutation.
+        // Generate "gql`...` as unknown as DocumentNode<query, variables>" to prevent manual
+        // addition of generics useGqlQuery / useGqlMutation.
         documentMode: DocumentMode.graphQLTag,
         // Remove `Document` suffix.
         documentVariableSuffix: '',
@@ -38,7 +37,12 @@ export default {
       } satisfies TypeScriptDocumentsPluginConfig & TypeScriptTypedDocumentNodesConfig,
     },
     'packages/api/src/schema.ts': {
-      config: { scalars, onlyOperationTypes: true },
+      // Schema used only for common types
+      // Patches prevent generating unconfigured params
+      config: {
+        scalars,
+        onlyOperationTypes: true,
+      },
       plugins: ['typescript'],
     },
   },

--- a/package.json
+++ b/package.json
@@ -55,5 +55,11 @@
     "hooks": {
       "prepare-commit-msg": "exec < /dev/tty && npx cz --hook || true"
     }
+  },
+  "pnpm": {
+    "patchedDependencies": {
+      "@graphql-codegen/visitor-plugin-common@5.8.0": "patches/@graphql-codegen__visitor-plugin-common@5.8.0.patch",
+      "@graphql-codegen/typescript@4.1.6": "patches/@graphql-codegen__typescript@4.1.6.patch"
+    }
   }
 }

--- a/packages/api/src/schema.ts
+++ b/packages/api/src/schema.ts
@@ -14,33 +14,3 @@ export type Scalars = {
   Float: { input: number; output: number; }
   Date: { input: string; output: string; }
 };
-
-export enum AppManagementInviteRole {
-  /** Provides the application write access. */
-  Admin = 'ADMIN',
-  /** Provides the application read access. */
-  Member = 'MEMBER'
-}
-
-export enum AppPrivacy {
-  /** Application is visible only to application managers. */
-  Hidden = 'HIDDEN',
-  /** Application is visible to all users. */
-  Visible = 'VISIBLE'
-}
-
-export enum AppRole {
-  /** Provides the application write access. */
-  Admin = 'ADMIN',
-  /** Provides the application read access. */
-  Member = 'MEMBER',
-  /** Application owner role. */
-  Owner = 'OWNER'
-}
-
-export type InputAppUrl = {
-  /** Platform identifier. */
-  platformID: Scalars['Int']['input'];
-  /** URL to set. */
-  url: Scalars['String']['input'];
-};

--- a/patches/@graphql-codegen__typescript@4.1.6.patch
+++ b/patches/@graphql-codegen__typescript@4.1.6.patch
@@ -1,0 +1,24 @@
+diff --git a/cjs/visitor.js b/cjs/visitor.js
+index 1f0e82e7c895a0fcd98bb4c975b9269524d4f898..f422b509ffbf0e38d1d7cc686e53432653386906 100644
+--- a/cjs/visitor.js
++++ b/cjs/visitor.js
+@@ -226,6 +226,7 @@ class TsVisitor extends visitor_plugin_common_1.BaseTypesVisitor {
+         return comment + (0, visitor_plugin_common_1.indent)(buildFieldDefinition());
+     }
+     EnumTypeDefinition(node) {
++        if (true) return '';
+         const enumName = node.name;
+         // In case of mapped external enum string
+         if (this.config.enumValues[enumName]?.sourceFile) {
+diff --git a/esm/visitor.js b/esm/visitor.js
+index d46d3bae098cd20c7b62747145c358d13281411c..75b91e3c51e15398a20be9230a57b393f5fd1ce2 100644
+--- a/esm/visitor.js
++++ b/esm/visitor.js
+@@ -222,6 +222,7 @@ export class TsVisitor extends BaseTypesVisitor {
+         return comment + indent(buildFieldDefinition());
+     }
+     EnumTypeDefinition(node) {
++        if (true) return '';
+         const enumName = node.name;
+         // In case of mapped external enum string
+         if (this.config.enumValues[enumName]?.sourceFile) {

--- a/patches/@graphql-codegen__visitor-plugin-common@5.8.0.patch
+++ b/patches/@graphql-codegen__visitor-plugin-common@5.8.0.patch
@@ -1,0 +1,24 @@
+diff --git a/cjs/base-types-visitor.js b/cjs/base-types-visitor.js
+index 4116fdd00fa67f43e4b602d70809284aaf02690e..28ec8ab9f66fe01a4fd3aa5fa1db3e50b02b8842 100644
+--- a/cjs/base-types-visitor.js
++++ b/cjs/base-types-visitor.js
+@@ -142,6 +142,7 @@ class BaseTypesVisitor extends base_visitor_js_1.BaseVisitor {
+             .withContent(`\n` + node.fields.join('\n  |'));
+     }
+     InputObjectTypeDefinition(node) {
++        if (true) return '';
+         if (this.config.onlyEnums)
+             return '';
+         // Why the heck is node.name a string and not { value: string } at runtime ?!
+diff --git a/esm/base-types-visitor.js b/esm/base-types-visitor.js
+index cc62222e72752590461d40abb54070f85bda6e62..6cf4c69a5c6ed6791539d45381a8b0dc58f8eaa7 100644
+--- a/esm/base-types-visitor.js
++++ b/esm/base-types-visitor.js
+@@ -139,6 +139,7 @@ export class BaseTypesVisitor extends BaseVisitor {
+             .withContent(`\n` + node.fields.join('\n  |'));
+     }
+     InputObjectTypeDefinition(node) {
++        if (true) return '';
+         if (this.config.onlyEnums)
+             return '';
+         // Why the heck is node.name a string and not { value: string } at runtime ?!


### PR DESCRIPTION
Make schema only common types
Patches needs to configure types that cannot be configured